### PR TITLE
Fix compilation errors on modern Verilog standards

### DIFF
--- a/rtl/uart_rx.v
+++ b/rtl/uart_rx.v
@@ -6,7 +6,13 @@
 // - UART reciever module.
 //
 
-module uart_rx(
+module uart_rx #(
+// External parameters.
+parameter BIT_RATE     = 9600,       // bits / sec
+parameter CLK_HZ       = 50_000_000, // Clock frequency in hertz.
+parameter PAYLOAD_BITS = 8,          // Number of data bits per packet.
+parameter STOP_BITS    = 1           // Number of stop bits.
+) (
 input  wire       clk          , // Top level system clock input.
 input  wire       resetn       , // Asynchronous active low reset.
 input  wire       uart_rxd     , // UART Recieve pin.
@@ -16,28 +22,6 @@ output wire       uart_rx_valid, // Valid data recieved and available.
 output reg  [PAYLOAD_BITS-1:0] uart_rx_data   // The recieved data.
 );
 
-// --------------------------------------------------------------------------- 
-// External parameters.
-// 
-
-//
-// Input bit rate of the UART line.
-parameter   BIT_RATE        = 9600; // bits / sec
-localparam  BIT_P           = 1_000_000_000 * 1/BIT_RATE; // nanoseconds
-
-//
-// Clock frequency in hertz.
-parameter   CLK_HZ          =    50_000_000;
-localparam  CLK_P           = 1_000_000_000 * 1/CLK_HZ; // nanoseconds
-
-//
-// Number of data bits recieved per UART packet.
-parameter   PAYLOAD_BITS    = 8;
-
-//
-// Number of stop bits indicating the end of a packet.
-parameter   STOP_BITS       = 1;
-
 // -------------------------------------------------------------------------- 
 // Internal parameters.
 // 
@@ -45,6 +29,14 @@ parameter   STOP_BITS       = 1;
 //
 // Number of clock cycles per uart bit.
 localparam       CYCLES_PER_BIT     = BIT_P / CLK_P;
+
+//
+// Number of nanoseconds per bit.
+localparam  BIT_P           = 1_000_000_000 * 1/BIT_RATE;
+
+//
+// Number of nanoseconds per clock period.
+localparam  CLK_P           = 1_000_000_000 * 1/CLK_HZ;
 
 //
 // Size of the registers which store sample counts and bit durations.

--- a/rtl/uart_rx.v
+++ b/rtl/uart_rx.v
@@ -27,16 +27,16 @@ output reg  [PAYLOAD_BITS-1:0] uart_rx_data   // The recieved data.
 // 
 
 //
-// Number of clock cycles per uart bit.
-localparam       CYCLES_PER_BIT     = BIT_P / CLK_P;
-
-//
 // Number of nanoseconds per bit.
 localparam  BIT_P           = 1_000_000_000 * 1/BIT_RATE;
 
 //
 // Number of nanoseconds per clock period.
 localparam  CLK_P           = 1_000_000_000 * 1/CLK_HZ;
+
+//
+// Number of clock cycles per uart bit.
+localparam       CYCLES_PER_BIT     = BIT_P / CLK_P;
 
 //
 // Size of the registers which store sample counts and bit durations.

--- a/rtl/uart_tx.v
+++ b/rtl/uart_tx.v
@@ -27,16 +27,16 @@ input  wire [PAYLOAD_BITS-1:0]   uart_tx_data  // The data to be sent
 // 
 
 //
-// Number of clock cycles per uart bit.
-localparam       CYCLES_PER_BIT     = BIT_P / CLK_P;
-
-//
 // Number of nanoseconds per bit.
 localparam  BIT_P           = 1_000_000_000 * 1/BIT_RATE;
 
 //
 // Number of nanoseconds per clock period.
 localparam  CLK_P           = 1_000_000_000 * 1/CLK_HZ;
+
+//
+// Number of clock cycles per uart bit.
+localparam       CYCLES_PER_BIT     = BIT_P / CLK_P;
 
 //
 // Size of the registers which store sample counts and bit durations.

--- a/rtl/uart_tx.v
+++ b/rtl/uart_tx.v
@@ -7,7 +7,13 @@
 // - UART transmitter module.
 //
 
-module uart_tx(
+module uart_tx #(
+// External parameters.
+parameter BIT_RATE     = 9600,       // bits / sec
+parameter CLK_HZ       = 50_000_000, // Clock frequency in hertz.
+parameter PAYLOAD_BITS = 8,          // Number of data bits per packet.
+parameter STOP_BITS    = 1           // Number of stop bits.
+) (
 input  wire         clk         , // Top level system clock input.
 input  wire         resetn      , // Asynchronous active low reset.
 output wire         uart_txd    , // UART transmit pin.
@@ -17,34 +23,20 @@ input  wire [PAYLOAD_BITS-1:0]   uart_tx_data  // The data to be sent
 );
 
 // --------------------------------------------------------------------------- 
-// External parameters.
-// 
-
-//
-// Input bit rate of the UART line.
-parameter   BIT_RATE        = 9600; // bits / sec
-localparam  BIT_P           = 1_000_000_000 * 1/BIT_RATE; // nanoseconds
-
-//
-// Clock frequency in hertz.
-parameter   CLK_HZ          =    50_000_000;
-localparam  CLK_P           = 1_000_000_000 * 1/CLK_HZ; // nanoseconds
-
-//
-// Number of data bits recieved per UART packet.
-parameter   PAYLOAD_BITS    = 8;
-
-//
-// Number of stop bits indicating the end of a packet.
-parameter   STOP_BITS       = 1;
-
-// --------------------------------------------------------------------------- 
 // Internal parameters.
 // 
 
 //
 // Number of clock cycles per uart bit.
 localparam       CYCLES_PER_BIT     = BIT_P / CLK_P;
+
+//
+// Number of nanoseconds per bit.
+localparam  BIT_P           = 1_000_000_000 * 1/BIT_RATE;
+
+//
+// Number of nanoseconds per clock period.
+localparam  CLK_P           = 1_000_000_000 * 1/CLK_HZ;
 
 //
 // Size of the registers which store sample counts and bit durations.


### PR DESCRIPTION
Parameters are currently being used before being defined.

`input wire [PAYLOAD_BITS-1:0] uart_tx_data` references the parameter `PAYLOAD_BITS` before it has been defined outside the port declarations. This results in compilation errors on modern Verilog standards.

This issue is located in `uart_tx.v` and `uart_rx.v`.

This fix moves the parameters to the module header so they can be defined before being used with the ports.